### PR TITLE
GLFW 3 and save PGM

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -17,6 +17,8 @@ using namespace glm;
 
 Camera::Camera()
 {
+    _position = vec3(0.0);
+    _forward = fquat(1.0f,0.0f,0.0f,0.0f);
     SetProjection();
 }
 

--- a/Math/PerlinNoise.cpp
+++ b/Math/PerlinNoise.cpp
@@ -13,6 +13,7 @@
 #include "vector"
 
 #include <random>
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
 #include <glm/gtx/compatibility.hpp>
 #include "MathUtil.h"

--- a/TerrainFluid.pro
+++ b/TerrainFluid.pro
@@ -51,10 +51,10 @@ mac {
     QMAKE_CXXFLAGS += -fopenmp
     QMAKE_LFLAGS += -fopenmp
     CONFIG    += link_pkgconfig
-    PKGCONFIG += libglfw
+  # PKGCONFIG += libglfw
     LIBS+=-lboost_system
     LIBS+=-lboost_filesystem
-    LIBS+=-lGLEW
+    LIBS+=-lglfw -lGLEW
     LIBS+=-lGL
 
     copydata.commands = $(COPY_DIR) $$PWD/Resources $$OUT_PWD

--- a/TerrainFluidSimulation.cpp
+++ b/TerrainFluidSimulation.cpp
@@ -100,24 +100,24 @@ void TerrainFluidSimulation::runMainloop()
 void TerrainFluidSimulation::checkInput()
 {
     // exit
-    if (glfwGetKey(GLFW_KEY_ESC))
+    if (glfwGetKey(win,GLFW_KEY_ESCAPE))
     {
         _finished = true;
     }
 
-    if (glfwGetKey('O')) _rain = true;
-    if (glfwGetKey('P')) _rain = false;
+    if (glfwGetKey(win,'O')) _rain = true;
+    if (glfwGetKey(win,'P')) _rain = false;
 
-    if (glfwGetKey('K')) _flood = true;
-    if (glfwGetKey('L')) _flood = false;
+    if (glfwGetKey(win,'K')) _flood = true;
+    if (glfwGetKey(win,'L')) _flood = false;
 
 
     // move rain position
     float d = 1.0f;
-    if (glfwGetKey(GLFW_KEY_UP)) _rainPos.y += d;
-    if (glfwGetKey(GLFW_KEY_DOWN)) _rainPos.y -= d;
-    if (glfwGetKey(GLFW_KEY_RIGHT)) _rainPos.x += d;
-    if (glfwGetKey(GLFW_KEY_LEFT)) _rainPos.x -= d;
+    if (glfwGetKey(win,GLFW_KEY_UP)) _rainPos.y += d;
+    if (glfwGetKey(win,GLFW_KEY_DOWN)) _rainPos.y -= d;
+    if (glfwGetKey(win,GLFW_KEY_RIGHT)) _rainPos.x += d;
+    if (glfwGetKey(win,GLFW_KEY_LEFT)) _rainPos.x -= d;
 
     _simulation.rainPos = _rainPos;
 }
@@ -133,20 +133,20 @@ void TerrainFluidSimulation::cameraMovement(double dt)
     vec3 yAxis(0,1,0);
     vec3 xAxis(1,0,0);
 
-    if (glfwGetKey('D')) _cam.TranslateLocal(vec3(camSpeed,0,0));
-    if (glfwGetKey('A')) _cam.TranslateLocal(vec3(-camSpeed,0,0));
+    if (glfwGetKey(win,'D')) _cam.TranslateLocal(vec3(camSpeed,0,0));
+    if (glfwGetKey(win,'A')) _cam.TranslateLocal(vec3(-camSpeed,0,0));
 
-    if (glfwGetKey('R')) _cam.TranslateLocal(vec3(0,camSpeed,0));
-    if (glfwGetKey('F')) _cam.TranslateLocal(vec3(0,-camSpeed,0));
+    if (glfwGetKey(win,'R')) _cam.TranslateLocal(vec3(0,camSpeed,0));
+    if (glfwGetKey(win,'F')) _cam.TranslateLocal(vec3(0,-camSpeed,0));
 
-    if (glfwGetKey('W')) _cam.TranslateLocal(vec3(0,0,-camSpeed));
-    if (glfwGetKey('S')) _cam.TranslateLocal(vec3(0,0,camSpeed));
+    if (glfwGetKey(win,'W')) _cam.TranslateLocal(vec3(0,0,-camSpeed));
+    if (glfwGetKey(win,'S')) _cam.TranslateLocal(vec3(0,0,camSpeed));
 
-    if (glfwGetKey('Q')) _cam.GlobalRotate(yAxis,-rotSpeed);
-    if (glfwGetKey('E')) _cam.GlobalRotate(yAxis,rotSpeed);
+    if (glfwGetKey(win,'Q')) _cam.GlobalRotate(yAxis,-rotSpeed);
+    if (glfwGetKey(win,'E')) _cam.GlobalRotate(yAxis,rotSpeed);
 
-    if (glfwGetKey('T')) _cam.LocalRotate(xAxis,-rotSpeed);
-    if (glfwGetKey('G')) _cam.LocalRotate(xAxis,rotSpeed);
+    if (glfwGetKey(win,'T')) _cam.LocalRotate(xAxis,-rotSpeed);
+    if (glfwGetKey(win,'G')) _cam.LocalRotate(xAxis,rotSpeed);
 }
 
 void TerrainFluidSimulation::updatePhysics(double dt)
@@ -167,7 +167,7 @@ void TerrainFluidSimulation::render()
     // Resize
     int w,h;
     bool resize = false;
-    glfwGetWindowSize(&w,&h);
+    glfwGetWindowSize(win,&w,&h);
     if (w != _width)
     {
         _width = w;
@@ -214,7 +214,7 @@ void TerrainFluidSimulation::render()
     _testShader->UnBind();
 
     // finish
-    glfwSwapBuffers();
+    glfwSwapBuffers(win);
     glFinish();
 }
 

--- a/TerrainFluidSimulation.cpp
+++ b/TerrainFluidSimulation.cpp
@@ -39,6 +39,35 @@ void TerrainFluidSimulation::Stop()
     _finished = true;
 }
 
+void TerrainFluidSimulation::SavePGM( const char* file )
+{
+    const Grid2D<float>& grid = _simulation.terrain;
+    const float* it  = grid.ptr();
+    const float* end = it + grid.size();
+    float low  =  9999.0f;
+    float high = -9999.0f;
+    float scale;
+
+    for( ; it != end; ++it )
+    {
+        float n = *it;
+        if( low > n )
+            low = n;
+        if( high < n )
+            high = n;
+    }
+    scale = 255.0f / (high - low);
+
+    FILE* fp = fopen( file, "w" );
+    if( fp )
+    {
+        fprintf( fp, "P5 %d %d 255\n", grid.width(), grid.height() );
+        for( it = grid.ptr(); it != end; ++it )
+            fputc( int((*it - low) * scale), fp );
+        fclose( fp );
+    }
+}
+
 void TerrainFluidSimulation::runMainloop()
 {
     using namespace std::chrono;

--- a/TerrainFluidSimulation.h
+++ b/TerrainFluidSimulation.h
@@ -37,6 +37,7 @@ public:
     void Run();
 
     void Stop();
+    void SavePGM( const char* file );
 
 protected:
 

--- a/main.cpp
+++ b/main.cpp
@@ -19,12 +19,12 @@
 
 using namespace std;
 
+GLFWwindow* win = 0;
 TerrainFluidSimulation* simulationPtr = 0;
 
-int onWindowClose()
+void onWindowClose( GLFWwindow* )
 {
     if (simulationPtr) simulationPtr->Stop();
-    return GL_TRUE;
 }
 
 int main(int argc, char** argv)
@@ -63,24 +63,30 @@ int main(int argc, char** argv)
     }
 
 
-    glfwOpenWindowHint(GLFW_FSAA_SAMPLES, 4); // 4x antialiasing
+    glfwWindowHint(GLFW_SAMPLES, 4); // 4x antialiasing
     // Use OpenGL Core v3.2
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
-    glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
-    glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-    glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 
     // Open an OpenGL window
-    if( !glfwOpenWindow( windowWidth,windowHeight, 8,8,8,8,8,8, GLFW_WINDOW ) )
+    win = glfwCreateWindow( windowWidth, windowHeight, "Terrain", NULL, NULL );
+    if( ! win )
     {
         std::cerr << "[GLFW] Error opening window" << std::endl;
         glfwTerminate();
         exit(1);
     }
 
+    glfwMakeContextCurrent( win );
+
     int major, minor, rev;
 
-    glfwGetGLVersion(&major, &minor, &rev);
+    major = glfwGetWindowAttrib( win, GLFW_CONTEXT_VERSION_MAJOR );
+    minor = glfwGetWindowAttrib( win, GLFW_CONTEXT_VERSION_MINOR );
+    rev   = glfwGetWindowAttrib( win, GLFW_CONTEXT_REVISION );
+
 
     fprintf(stdout, "OpenGL version recieved: %d.%d.%d\n", major, minor, rev);
     // Init Glew (OpenGL Extension Loading)
@@ -101,12 +107,16 @@ int main(int argc, char** argv)
     // Start Simulation ////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////
 
-    glfwSetWindowCloseCallback(onWindowClose);
+    glfwSetWindowCloseCallback(win, onWindowClose);
+
 
     simulationPtr = new TerrainFluidSimulation(terrainDim);
     simulationPtr->Run();
 
     delete simulationPtr;
+    glfwDestroyWindow( win );
+    glfwTerminate();
+
     cout << "The end." << endl;
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,18 @@ void onWindowClose( GLFWwindow* )
     if (simulationPtr) simulationPtr->Stop();
 }
 
+void keyHandler( GLFWwindow*, int key, int /*code*/, int action, int mods )
+{
+    if( action == GLFW_PRESS )
+    {
+        //if( mods & GLFW_MOD_CONTROL && key == GLFW_KEY_S )
+        if( key == GLFW_KEY_F4 )
+        {
+            simulationPtr->SavePGM( "erosion.pgm" );
+        }
+    }
+}
+
 int main(int argc, char** argv)
 {
     // Settings ////////////////////////////////////////////////////////////
@@ -108,6 +120,7 @@ int main(int argc, char** argv)
     ////////////////////////////////////////////////////////////////////////
 
     glfwSetWindowCloseCallback(win, onWindowClose);
+    glfwSetKeyCallback(win, keyHandler);
 
 
     simulationPtr = new TerrainFluidSimulation(terrainDim);

--- a/platform_includes.h
+++ b/platform_includes.h
@@ -38,7 +38,6 @@
 #include <GL/glew.h> // brew install glew
 
 #include <GL/glx.h>
-#include <GL/glfw.h>
 
 
 
@@ -46,6 +45,9 @@
 // for Windows
 // No support, sorry
 #endif
+
+#include <GLFW/glfw3.h>
+extern GLFWwindow* win;
 
 typedef unsigned int uint;
 typedef unsigned long ulong;


### PR DESCRIPTION
Here are two changes which update GLFW to version 3 and implements saving a PGM heightmap image.

QMake PKGCONFIG of glfw did not work on Fedora, so I disabled it in TerrainFluid.pro.
